### PR TITLE
fix: replace batch scan with rolling interval scheduler #10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     ollama_url: str = "http://compgather-ollama:11434"
     ollama_model: str = "qwen2.5:1.5b"
     scan_schedule: str = "06:00"
+    scan_interval_minutes: int = 12
     log_level: str = "INFO"
     database_url: str = "sqlite+aiosqlite:///data/compgather.db"
     api_key: str = ""

--- a/app/routers/scanner.py
+++ b/app/routers/scanner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_api_key
@@ -55,6 +56,19 @@ async def trigger_scan(data: ScanCreate, session: AsyncSession = Depends(get_ses
     else:
         result = await session.execute(select(Source.id).where(Source.enabled == True))
         source_ids = list(result.scalars().all())
+
+    # Clean up stale scans stuck in pending/running for over 30 minutes
+    stale_cutoff = datetime.utcnow() - timedelta(minutes=30)
+    await session.execute(
+        update(Scan)
+        .where(
+            Scan.source_id.in_(source_ids),
+            Scan.status.in_(["running", "pending"]),
+            Scan.started_at < stale_cutoff,
+        )
+        .values(status="failed", error="Stale scan cleaned up")
+    )
+    await session.commit()
 
     # Skip sources that already have an active (running/pending) scan
     busy_result = await session.execute(

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy import select
@@ -15,18 +16,33 @@ scheduler = AsyncIOScheduler()
 
 
 def start_scheduler():
-    """Start the daily scan scheduler."""
+    """Start the rolling scan scheduler and daily discipline audit."""
+    # Rolling scan: pick one due source every N minutes
+    scheduler.add_job(
+        _run_next_scan,
+        "interval",
+        minutes=settings.scan_interval_minutes,
+        id="rolling_scan",
+        replace_existing=True,
+    )
+
+    # Daily discipline audit at the configured hour
     hour, minute = settings.scan_schedule.split(":")
     scheduler.add_job(
-        _run_scan_job,
+        _run_discipline_audit,
         "cron",
         hour=int(hour),
         minute=int(minute),
-        id="daily_scan",
+        id="daily_audit",
         replace_existing=True,
     )
+
     scheduler.start()
-    logger.info("Scheduler started: daily scan at %s", settings.scan_schedule)
+    logger.info(
+        "Scheduler started: rolling scan every %d min, audit at %s",
+        settings.scan_interval_minutes,
+        settings.scan_schedule,
+    )
 
 
 def stop_scheduler():
@@ -36,35 +52,54 @@ def stop_scheduler():
         logger.info("Scheduler stopped")
 
 
-async def _run_scan_job():
-    """Scheduled scan: create one scan record per enabled source."""
+async def _run_next_scan():
+    """Pick the source most overdue for scanning and run it."""
     SCHEDULER_LAST_RUN.set_to_current_time()
-    logger.info("Scheduled scan starting")
+    cutoff = datetime.utcnow() - timedelta(hours=24)
+
     async with async_session() as session:
-        result = await session.execute(select(Source).where(Source.enabled == True))
-        sources = result.scalars().all()
-
-        for source in sources:
-            scan = Scan(source_id=source.id, status="pending")
-            session.add(scan)
-        await session.commit()
-
-        for source in sources:
-            # Get the scan we just created for this source
-            scan_result = await session.execute(
-                select(Scan).where(
-                    Scan.source_id == source.id, Scan.status == "pending"
-                ).order_by(Scan.id.desc()).limit(1)
+        # Find enabled source not scanned in last 24h, oldest first.
+        # Sources never scanned (last_scanned_at IS NULL) come first.
+        result = await session.execute(
+            select(Source)
+            .where(Source.enabled == True)
+            .where(
+                (Source.last_scanned_at == None) | (Source.last_scanned_at < cutoff)  # noqa: E711
             )
-            scan = scan_result.scalar_one_or_none()
-            if scan:
-                await run_scan(source.id, scan_id=scan.id)
+            .order_by(Source.last_scanned_at.asc().nulls_first())
+            .limit(1)
+        )
+        source = result.scalar_one_or_none()
 
-    # Post-scan: audit and normalise discipline values
+        if not source:
+            logger.debug("No sources due for scanning")
+            return
+
+        # Check no existing pending/running scan for this source
+        busy = await session.execute(
+            select(Scan.id).where(
+                Scan.source_id == source.id,
+                Scan.status.in_(["pending", "running"]),
+            )
+        )
+        if busy.scalar_one_or_none():
+            logger.debug("Source %s already has a pending/running scan, skipping", source.name)
+            return
+
+        scan = Scan(source_id=source.id, status="pending")
+        session.add(scan)
+        await session.commit()
+        scan_id = scan.id
+
+    logger.info("Rolling scan: %s (last scanned %s)", source.name, source.last_scanned_at)
+    await run_scan(source.id, scan_id=scan_id)
+
+
+async def _run_discipline_audit():
+    """Daily discipline audit and normalisation."""
     async with async_session() as session:
         try:
             await audit_disciplines(session)
+            logger.info("Daily discipline audit complete")
         except Exception as e:
             logger.warning("Discipline audit failed: %s", e)
-
-    logger.info("Scheduled scan complete for %d sources", len(sources))


### PR DESCRIPTION
## Summary

- Reverted Dockerfile to single uvicorn worker — multi-worker caused 4 APScheduler instances to deadlock on SQLite's single-writer lock, leaving all scans stuck in "pending"
- Replaced daily batch scan (all 122 sources at 06:00) with rolling interval scanner — one source every 12 minutes, spread evenly across 24 hours
- Added stale scan cleanup on manual trigger — scans stuck pending/running >30 min are marked failed so they no longer block new scans
- Discipline audit remains as a separate daily cron job

## Test plan

- [x] All 221 tests pass
- [x] Docker image builds successfully
- [ ] Deploy and verify scans progress from pending to completed
- [ ] Verify manual scan trigger works and is not blocked by stale records