### PR TITLE
refactor: rename compGather → EquiCalendar in code and config #14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,11 +148,11 @@ Tests run inside the Docker container:
 
 ```bash
 # Copy tests into container and run
-docker compose cp tests/ compgather:/app/tests/
-docker compose exec compgather pytest tests/ -v
+docker compose cp tests/ equicalendar:/app/tests/
+docker compose exec equicalendar pytest tests/ -v
 
 # Run a single test file
-docker compose exec compgather pytest tests/test_parsers.py -v
+docker compose exec equicalendar pytest tests/test_parsers.py -v
 ```
 
 ## Code Style

--- a/FIXES_NEEDED.md
+++ b/FIXES_NEEDED.md
@@ -12,7 +12,7 @@ These 9 parsers have Phase 4B done but Phase 4A skipped. They still filter out p
 
 ### 1. addington.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/addington.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/addington.py`
 
 **Line 13 - Remove import:**
 ```python
@@ -56,7 +56,7 @@ if not is_future_event(date_start, date_end):  # ← REMOVE THESE 2 LINES
 
 ### 2. arena_uk.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/arena_uk.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/arena_uk.py`
 
 **Line 14 - Remove import:**
 ```python
@@ -86,7 +86,7 @@ if not is_future_event(date_start, date_end):  # ← REMOVE THESE 2 LINES
 
 ### 3. ashwood.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/ashwood.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/ashwood.py`
 
 **Line 14 - Remove import:**
 ```python
@@ -126,7 +126,7 @@ if not is_future_event(date_start):  # ← REMOVE THESE 2 LINES
 
 ### 4. horsevents.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/horsevents.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/horsevents.py`
 
 **Line 14 - Remove import:**
 ```python
@@ -151,7 +151,7 @@ if not is_future_event(date_start, date_end):  # ← REMOVE THESE 2 LINES
 
 ### 5. my_riding_life.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/my_riding_life.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/my_riding_life.py`
 
 **Line 14 - Remove import:**
 ```python
@@ -181,7 +181,7 @@ if not is_future_event(date_start, date_end):  # ← REMOVE THESE 2 LINES
 
 ### 6. pony_club.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/pony_club.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/pony_club.py`
 
 **Line 13 - Remove import:**
 ```python
@@ -206,7 +206,7 @@ if not is_future_event(date_start):  # ← REMOVE THESE 2 LINES
 
 ### 7. showground.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/showground.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/showground.py`
 
 **Line 14 - Remove import:**
 ```python
@@ -236,7 +236,7 @@ if not is_future_event(date_start_str, date_end_str):  # ← REMOVE THESE 2 LINE
 
 ### 8. british_showjumping.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/british_showjumping.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/british_showjumping.py`
 
 **Line 13 - Remove import:**
 ```python
@@ -262,7 +262,7 @@ if is_future_event(date_start, date_end):  # ← INVERT THIS (remove the check)
 
 ### 9. equipe_online.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/equipe_online.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/equipe_online.py`
 
 **Line 10 - Remove import:**
 ```python
@@ -290,7 +290,7 @@ These 5 parsers were explicitly listed as Phase 4A fixed but git diff shows zero
 
 ### 1. brook_farm.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/brook_farm.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/brook_farm.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -310,7 +310,7 @@ if not is_future_event(date_start):
 
 ### 2. dean_valley.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/dean_valley.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/dean_valley.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -330,7 +330,7 @@ if not is_future_event(date_start):
 
 ### 3. hartpury.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/hartpury.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/hartpury.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -350,7 +350,7 @@ if not is_future_event(date_start):
 
 ### 4. northallerton.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/northallerton.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/northallerton.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -370,7 +370,7 @@ if not is_future_event(date_start):
 
 ### 5. port_royal.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/port_royal.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/port_royal.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -392,7 +392,7 @@ if not is_future_event(date_start):
 
 ### 1. solihull.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/solihull.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/solihull.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -412,7 +412,7 @@ if not is_future_event(date_start):
 
 ### 2. sykehouse.py
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/sykehouse.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/sykehouse.py`
 
 **Line 12 - Remove import:**
 ```python
@@ -432,7 +432,7 @@ if not is_future_event(date_start):
 
 ### 3. horse_events.py (SPECIAL CASE - Most Complex)
 
-**File:** `/Users/darrylcauldwell/Library/Mobile Documents/com~apple~CloudDocs/Development/compGather/app/parsers/horse_events.py`
+**File:** `/Users/darrylcauldwell/Development/compGather/app/parsers/horse_events.py`
 
 **Line 14 - Remove classify_event import:**
 ```python

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ EquiCalendar scrapes all major UK equestrian listing sites daily, normalises the
 ```bash
 # Clone
 git clone https://github.com/darrylcauldwell/compGather.git
-cd compGather
+cd EquiCalendar
 
 # Start (builds Docker image with all dependencies)
 docker compose up -d --build

--- a/app/config.py
+++ b/app/config.py
@@ -2,12 +2,12 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    ollama_url: str = "http://compgather-ollama:11434"
+    ollama_url: str = "http://equicalendar-ollama:11434"
     ollama_model: str = "qwen2.5:1.5b"
     scan_schedule: str = "06:00"
     scan_interval_minutes: int = 12
     log_level: str = "INFO"
-    database_url: str = "sqlite+aiosqlite:///data/compgather.db"
+    database_url: str = "sqlite+aiosqlite:///data/equicalendar.db"
     api_key: str = ""
     analytics_domain: str = ""
 

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,6 +1,6 @@
-"""Prometheus metrics for CompGather (EquiCalendar).
+"""Prometheus metrics for EquiCalendar.
 
-All custom metrics use the 'compgather_' prefix to avoid conflicts
+All custom metrics use the 'equicalendar_' prefix to avoid conflicts
 with other applications in a shared observability stack.
 """
 
@@ -17,75 +17,75 @@ except ImportError:
 
 # Application info
 APP_INFO = Info(
-    "compgather_app",
-    "CompGather application info"
+    "equicalendar_app",
+    "EquiCalendar application info"
 )
 APP_INFO.info({"version": "1.0.0", "name": "equicalendar"})
 
 # Scan metrics
 SCAN_DURATION_SECONDS = Histogram(
-    "compgather_scan_duration_seconds",
+    "equicalendar_scan_duration_seconds",
     "Duration of source scans in seconds",
     ["source_name", "parser_key"],
     buckets=[1, 5, 10, 30, 60, 120, 300, 600],
 )
 
 SCAN_TOTAL = Counter(
-    "compgather_scans_total",
+    "equicalendar_scans_total",
     "Total number of scans by status",
     ["source_name", "status"],  # status: completed, failed
 )
 
 SCAN_COMPETITIONS_FOUND = Gauge(
-    "compgather_scan_competitions_found",
+    "equicalendar_scan_competitions_found",
     "Number of competitions found in last scan",
     ["source_name"],
 )
 
 # Venue metrics
 VENUE_MATCH_TOTAL = Counter(
-    "compgather_venue_matches_total",
+    "equicalendar_venue_matches_total",
     "Venue match outcomes by type",
     ["match_type"],  # alias, prefix, postcode, new, fuzzy, etc.
 )
 
 VENUES_TOTAL = Gauge(
-    "compgather_venues_total",
+    "equicalendar_venues_total",
     "Total number of venues",
     ["source"],  # seed_data, dynamic
 )
 
 VENUES_WITH_COORDS = Gauge(
-    "compgather_venues_with_coordinates",
+    "equicalendar_venues_with_coordinates",
     "Number of venues that have been geocoded",
 )
 
 # Competition metrics
 COMPETITIONS_ACTIVE = Gauge(
-    "compgather_competitions_active",
+    "equicalendar_competitions_active",
     "Number of active future competitions",
 )
 
 COMPETITIONS_BY_DISCIPLINE = Gauge(
-    "compgather_competitions_by_discipline",
+    "equicalendar_competitions_by_discipline",
     "Competition count by discipline",
     ["discipline"],
 )
 
 # Data quality
 SOURCES_ENABLED = Gauge(
-    "compgather_sources_enabled",
+    "equicalendar_sources_enabled",
     "Number of enabled sources",
 )
 
 PARSER_ERRORS_TOTAL = Counter(
-    "compgather_parser_errors_total",
+    "equicalendar_parser_errors_total",
     "Parser errors by source",
     ["source_name", "error_type"],
 )
 
 # Scheduler
 SCHEDULER_LAST_RUN = Gauge(
-    "compgather_scheduler_last_run_timestamp",
+    "equicalendar_scheduler_last_run_timestamp",
     "Unix timestamp of last scheduled scan run",
 )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,21 +1,21 @@
 services:
-  compgather:
-    image: ghcr.io/darrylcauldwell/compgather:latest
-    container_name: compgather
+  equicalendar:
+    image: ghcr.io/darrylcauldwell/equicalendar:latest
+    container_name: equicalendar
     restart: unless-stopped
     ports:
       - "127.0.0.1:8001:8000"
     environment:
       - HOME_POSTCODE=${HOME_POSTCODE}
-      - OLLAMA_URL=http://compgather-ollama:11434
+      - OLLAMA_URL=http://equicalendar-ollama:11434
       - SCAN_SCHEDULE=06:00
       - LOG_LEVEL=INFO
       - API_KEY=${API_KEY}
       - ANALYTICS_DOMAIN=${ANALYTICS_DOMAIN:-}
     volumes:
-      - compgather_data:/app/data
+      - equicalendar_data:/app/data
     depends_on:
-      compgather-ollama:
+      equicalendar-ollama:
         condition: service_healthy
     networks:
       - web
@@ -36,9 +36,9 @@ services:
       start_period: 30s
       retries: 3
 
-  compgather-ollama:
+  equicalendar-ollama:
     image: ollama/ollama:latest
-    container_name: compgather-ollama
+    container_name: equicalendar-ollama
     restart: unless-stopped
     volumes:
       - ollama_data:/root/.ollama
@@ -56,7 +56,7 @@ services:
       retries: 3
 
 volumes:
-  compgather_data:
+  equicalendar_data:
   ollama_data:
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  compgather:
+  equicalendar:
     build: .
-    container_name: compgather
+    container_name: equicalendar
     ports:
       - "127.0.0.1:8001:8000"
     environment:
@@ -13,7 +13,7 @@ services:
       - ANALYTICS_DOMAIN=${ANALYTICS_DOMAIN:-}
     volumes:
       - ./app:/app/app
-      - compgather_data:/app/data
+      - equicalendar_data:/app/data
     networks:
       - web
     healthcheck:
@@ -23,9 +23,9 @@ services:
       start_period: 30s
       retries: 3
 
-  compgather-prometheus:
+  equicalendar-prometheus:
     image: prom/prometheus:v2.50.0
-    container_name: compgather-prometheus
+    container_name: equicalendar-prometheus
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
@@ -33,7 +33,7 @@ services:
       - --storage.tsdb.retention.time=15d
     volumes:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - compgather_prometheus_data:/prometheus
+      - equicalendar_prometheus_data:/prometheus
     networks:
       - web
     healthcheck:
@@ -43,9 +43,9 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-grafana:
+  equicalendar-grafana:
     image: grafana/grafana:10.3.1
-    container_name: compgather-grafana
+    container_name: equicalendar-grafana
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"
@@ -57,7 +57,7 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
-      - compgather_grafana_data:/var/lib/grafana
+      - equicalendar_grafana_data:/var/lib/grafana
     networks:
       - web
     healthcheck:
@@ -67,14 +67,14 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-loki:
+  equicalendar-loki:
     image: grafana/loki:3.0.0
-    container_name: compgather-loki
+    container_name: equicalendar-loki
     restart: unless-stopped
     command: -config.file=/etc/loki/loki-config.yml
     volumes:
       - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
-      - compgather_loki_data:/loki
+      - equicalendar_loki_data:/loki
     networks:
       - web
     healthcheck:
@@ -84,9 +84,9 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-promtail:
+  equicalendar-promtail:
     image: grafana/promtail:3.0.0
-    container_name: compgather-promtail
+    container_name: equicalendar-promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail-config.yml
     volumes:
@@ -96,7 +96,7 @@ services:
     networks:
       - web
     depends_on:
-      compgather-loki:
+      equicalendar-loki:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9080/metrics"]
@@ -105,9 +105,9 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-cadvisor:
+  equicalendar-cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
-    container_name: compgather-cadvisor
+    container_name: equicalendar-cadvisor
     restart: unless-stopped
     privileged: true
     command:
@@ -128,10 +128,10 @@ services:
       start_period: 10s
 
 volumes:
-  compgather_data:
-  compgather_prometheus_data:
-  compgather_grafana_data:
-  compgather_loki_data:
+  equicalendar_data:
+  equicalendar_prometheus_data:
+  equicalendar_grafana_data:
+  equicalendar_loki_data:
 
 networks:
   web:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ EquiCalendar is a **scrape-normalise-store-serve** pipeline that aggregates UK e
 ## 2. Directory Structure
 
 ```
-compGather/
+EquiCalendar/
 ├── app/
 │   ├── config.py              # pydantic-settings: env vars
 │   ├── database.py            # async SQLAlchemy engine + migrations

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -379,7 +379,7 @@ or support rollbacks.
 
 ### Pitfall: Data loss on container recreation
 
-SQLite file is stored in a Docker named volume (`compgather_data`). This
+SQLite file is stored in a Docker named volume (`equicalendar_data`). This
 survives container recreates but NOT `docker compose down -v`.
 
 **Current mitigations (data resilience)**:

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  compgather-prometheus:
+  equicalendar-prometheus:
     image: prom/prometheus:v2.50.0
-    container_name: compgather-prometheus
+    container_name: equicalendar-prometheus
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
@@ -9,7 +9,7 @@ services:
       - --storage.tsdb.retention.time=15d
     volumes:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - compgather_prometheus_data:/prometheus
+      - equicalendar_prometheus_data:/prometheus
     networks:
       - web
     healthcheck:
@@ -19,9 +19,9 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-grafana:
+  equicalendar-grafana:
     image: grafana/grafana:10.3.1
-    container_name: compgather-grafana
+    container_name: equicalendar-grafana
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"
@@ -33,7 +33,7 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
-      - compgather_grafana_data:/var/lib/grafana
+      - equicalendar_grafana_data:/var/lib/grafana
     networks:
       - web
     healthcheck:
@@ -43,14 +43,14 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-loki:
+  equicalendar-loki:
     image: grafana/loki:3.0.0
-    container_name: compgather-loki
+    container_name: equicalendar-loki
     restart: unless-stopped
     command: -config.file=/etc/loki/loki-config.yml
     volumes:
       - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
-      - compgather_loki_data:/loki
+      - equicalendar_loki_data:/loki
     networks:
       - web
     healthcheck:
@@ -60,9 +60,9 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-promtail:
+  equicalendar-promtail:
     image: grafana/promtail:3.0.0
-    container_name: compgather-promtail
+    container_name: equicalendar-promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail-config.yml
     volumes:
@@ -72,7 +72,7 @@ services:
     networks:
       - web
     depends_on:
-      compgather-loki:
+      equicalendar-loki:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9080/metrics"]
@@ -81,9 +81,9 @@ services:
       retries: 3
       start_period: 10s
 
-  compgather-cadvisor:
+  equicalendar-cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
-    container_name: compgather-cadvisor
+    container_name: equicalendar-cadvisor
     restart: unless-stopped
     privileged: true
     command:
@@ -104,6 +104,6 @@ services:
       start_period: 10s
 
 volumes:
-  compgather_prometheus_data:
-  compgather_grafana_data:
-  compgather_loki_data:
+  equicalendar_prometheus_data:
+  equicalendar_grafana_data:
+  equicalendar_loki_data:

--- a/observability/grafana/provisioning/dashboards/dashboards/equicalendar-overview.json
+++ b/observability/grafana/provisioning/dashboards/dashboards/equicalendar-overview.json
@@ -36,7 +36,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "compgather_competitions_active",
+          "expr": "equicalendar_competitions_active",
           "refId": "A"
         }
       ],
@@ -60,7 +60,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "compgather_sources_enabled",
+          "expr": "equicalendar_sources_enabled",
           "refId": "A"
         }
       ],
@@ -84,7 +84,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "compgather_venues_with_coordinates",
+          "expr": "equicalendar_venues_with_coordinates",
           "refId": "A"
         }
       ],
@@ -113,7 +113,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum by (source) (compgather_venues_total)",
+          "expr": "sum by (source) (equicalendar_venues_total)",
           "refId": "A"
         }
       ],
@@ -159,7 +159,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "rate(http_requests_total{job=\"compgather\"}[5m])",
+          "expr": "rate(http_requests_total{job=\"equicalendar\"}[5m])",
           "legendFormat": "{{handler}}",
           "refId": "A"
         }
@@ -206,12 +206,12 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job=\"compgather\"}[5m])) * 1000",
+          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job=\"equicalendar\"}[5m])) * 1000",
           "legendFormat": "p95",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket{job=\"compgather\"}[5m])) * 1000",
+          "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket{job=\"equicalendar\"}[5m])) * 1000",
           "legendFormat": "p99",
           "refId": "B"
         }
@@ -223,13 +223,13 @@
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["compgather", "overview"],
+  "tags": ["equicalendar", "overview"],
   "templating": {"list": []},
   "time": {"from": "now-6h", "to": "now"},
   "timepicker": {},
   "timezone": "",
-  "title": "CompGather Overview",
-  "uid": "compgather-overview",
+  "title": "EquiCalendar Overview",
+  "uid": "equicalendar-overview",
   "version": 0,
   "weekStart": ""
 }

--- a/observability/grafana/provisioning/dashboards/dashboards/equicalendar-scans.json
+++ b/observability/grafana/provisioning/dashboards/dashboards/equicalendar-scans.json
@@ -58,7 +58,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, rate(compgather_scan_duration_seconds_bucket[5m]))",
+          "expr": "histogram_quantile(0.95, rate(equicalendar_scan_duration_seconds_bucket[5m]))",
           "legendFormat": "{{source_name}} (p95)",
           "refId": "A"
         }
@@ -105,7 +105,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "compgather_scan_competitions_found",
+          "expr": "equicalendar_scan_competitions_found",
           "legendFormat": "{{source_name}}",
           "refId": "A"
         }
@@ -136,7 +136,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum by (match_type) (compgather_venue_matches_total)",
+          "expr": "sum by (match_type) (equicalendar_venue_matches_total)",
           "refId": "A"
         }
       ],
@@ -167,7 +167,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum by (source_name, status) (compgather_scans_total)",
+          "expr": "sum by (source_name, status) (equicalendar_scans_total)",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -210,7 +210,7 @@
       "pluginVersion": "10.3.1",
       "targets": [
         {
-          "expr": "sum by (source_name, error_type) (compgather_parser_errors_total)",
+          "expr": "sum by (source_name, error_type) (equicalendar_parser_errors_total)",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -233,13 +233,13 @@
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["compgather", "scans"],
+  "tags": ["equicalendar", "scans"],
   "templating": {"list": []},
   "time": {"from": "now-24h", "to": "now"},
   "timepicker": {},
   "timezone": "",
-  "title": "CompGather Scans",
-  "uid": "compgather-scans",
+  "title": "EquiCalendar Scans",
+  "uid": "equicalendar-scans",
   "version": 0,
   "weekStart": ""
 }

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -5,7 +5,7 @@ datasources:
     type: prometheus
     uid: prometheus
     access: proxy
-    url: http://compgather-prometheus:9090
+    url: http://equicalendar-prometheus:9090
     isDefault: true
     editable: false
 
@@ -13,5 +13,5 @@ datasources:
     type: loki
     uid: loki
     access: proxy
-    url: http://compgather-loki:3100
+    url: http://equicalendar-loki:3100
     editable: false

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -9,9 +9,9 @@ scrape_configs:
 
   - job_name: 'cadvisor'
     static_configs:
-      - targets: ['compgather-cadvisor:8080']
+      - targets: ['equicalendar-cadvisor:8080']
 
-  - job_name: 'compgather'
+  - job_name: 'equicalendar'
     static_configs:
-      - targets: ['compgather:8000']
+      - targets: ['equicalendar:8000']
     metrics_path: /metrics

--- a/scripts/backfill_venue_id.py
+++ b/scripts/backfill_venue_id.py
@@ -2,7 +2,7 @@
 """One-off migration script: backfill venue_id on competitions table.
 
 Run inside the Docker container after deploying the venue FK migration:
-    docker exec compgather python scripts/backfill_venue_id.py
+    docker exec equicalendar python scripts/backfill_venue_id.py
 
 What it does:
 1. For each competition with NULL venue_id, match venue_name → venues.name
@@ -18,7 +18,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-DB_PATH = Path("data/compgather.db")
+DB_PATH = Path("data/equicalendar.db")
 
 
 def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -6,18 +6,18 @@
 # Keeps the last 7 daily backups.
 #
 # Can be run from cron:
-#   0 2 * * * /path/to/compGather/scripts/backup.sh
+#   0 2 * * * /path/to/EquiCalendar/scripts/backup.sh
 #
 # Or via docker exec:
-#   docker exec compgather /app/scripts/backup.sh /app/data/backups
+#   docker exec equicalendar /app/scripts/backup.sh /app/data/backups
 
 set -euo pipefail
 
-DB_PATH="${DB_PATH:-/app/data/compgather.db}"
+DB_PATH="${DB_PATH:-/app/data/equicalendar.db}"
 BACKUP_DIR="${1:-/app/data/backups}"
 KEEP_DAYS=7
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-BACKUP_FILE="${BACKUP_DIR}/compgather-${TIMESTAMP}.db"
+BACKUP_FILE="${BACKUP_DIR}/equicalendar-${TIMESTAMP}.db"
 
 # Create backup directory if needed
 mkdir -p "${BACKUP_DIR}"
@@ -33,11 +33,11 @@ else
 fi
 
 # Rotate: delete backups older than KEEP_DAYS
-find "${BACKUP_DIR}" -name "compgather-*.db" -mtime +${KEEP_DAYS} -delete 2>/dev/null || true
-find "${BACKUP_DIR}" -name "compgather-*.db-wal" -mtime +${KEEP_DAYS} -delete 2>/dev/null || true
-find "${BACKUP_DIR}" -name "compgather-*.db-shm" -mtime +${KEEP_DAYS} -delete 2>/dev/null || true
+find "${BACKUP_DIR}" -name "equicalendar-*.db" -mtime +${KEEP_DAYS} -delete 2>/dev/null || true
+find "${BACKUP_DIR}" -name "equicalendar-*.db-wal" -mtime +${KEEP_DAYS} -delete 2>/dev/null || true
+find "${BACKUP_DIR}" -name "equicalendar-*.db-shm" -mtime +${KEEP_DAYS} -delete 2>/dev/null || true
 
 echo "Backup complete: ${BACKUP_FILE}"
 ls -lh "${BACKUP_FILE}"
 echo "Backups in ${BACKUP_DIR}:"
-ls -1t "${BACKUP_DIR}"/compgather-*.db 2>/dev/null | head -10
+ls -1t "${BACKUP_DIR}"/equicalendar-*.db 2>/dev/null | head -10

--- a/scripts/find_duplicate_postcodes.py
+++ b/scripts/find_duplicate_postcodes.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from collections import defaultdict
 
 # Database path
-db_path = Path(__file__).parent.parent / "compGather.db"
+db_path = Path(__file__).parent.parent / "equicalendar.db"
 
 def find_duplicate_postcodes():
     """Query database for postcodes with multiple venues."""

--- a/scripts/fix_venue_data.py
+++ b/scripts/fix_venue_data.py
@@ -2,7 +2,7 @@
 """One-off script to fix HIGH priority venue data quality issues.
 
 Run inside the Docker container:
-    docker exec compgather python scripts/fix_venue_data.py
+    docker exec equicalendar python scripts/fix_venue_data.py
 
 What it does:
 A) Fix NULL distance_miles on venues that have coordinates
@@ -22,7 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from app.parsers.utils import normalise_postcode  # noqa: E402
 
-DB_PATH = Path("data/compgather.db")
+DB_PATH = Path("data/equicalendar.db")
 
 # Disambiguated venue name pattern: "Brook Farm (TQ12)"
 _DISAMBIGUATED_RE = re.compile(r"\(([A-Z]{1,2}\d[A-Z\d]?)\)$")

--- a/scripts/renormalise_venues.py
+++ b/scripts/renormalise_venues.py
@@ -2,7 +2,7 @@
 """One-off script to re-normalise venue names after alias/suffix updates.
 
 Runs inside the Docker container:
-    docker exec compgather python scripts/renormalise_venues.py
+    docker exec equicalendar python scripts/renormalise_venues.py
 
 What it does (post venue-FK migration):
 1. Re-normalises venue names in the venues table
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from app.parsers.utils import disambiguate_venue, normalise_venue_name  # noqa: E402
 from app.seed_data import get_venue_aliases  # noqa: E402
 
-DB_PATH = Path("data/compgather.db")
+DB_PATH = Path("data/equicalendar.db")
 
 
 def _resolve_name(name: str, postcode: str | None = None) -> str:

--- a/scripts/seed_new_sources.py
+++ b/scripts/seed_new_sources.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Seed script to register new equestrian sources via the compGather API.
+"""Seed script to register new equestrian sources via the EquiCalendar API.
 
 Usage:
     python scripts/seed_new_sources.py [--base-url http://localhost:8001]
@@ -49,7 +49,7 @@ NEW_SOURCES = [
 
 def main():
     parser = argparse.ArgumentParser(description="Seed new equestrian sources")
-    parser.add_argument("--base-url", default="http://localhost:8001", help="compGather API base URL")
+    parser.add_argument("--base-url", default="http://localhost:8001", help="EquiCalendar API base URL")
     args = parser.parse_args()
 
     base = args.base_url.rstrip("/")

--- a/scripts/validate_venue_seeds.py
+++ b/scripts/validate_venue_seeds.py
@@ -10,7 +10,7 @@ Checks:
   E) Coord-only completeness — venues with coords but no postcode
 
 Run inside Docker:
-    docker exec compgather python scripts/validate_venue_seeds.py
+    docker exec equicalendar python scripts/validate_venue_seeds.py
 
 Or locally (requires requests):
     python3 scripts/validate_venue_seeds.py


### PR DESCRIPTION
## Summary
- Renamed all `compgather` references to `equicalendar` across 21 files: Prometheus metrics prefix, Docker Compose service/container/volume names, observability config, Grafana dashboards (renamed files + updated content), app config (DB path, Ollama URL), scripts (container names, DB paths), and documentation
- GitHub URLs kept as-is (deferred to #15 repo rename)

## Test plan
- [x] `grep -ri compgather` returns zero hits in code/config files (only GitHub URLs remain)
- [x] All YAML and JSON files pass syntax validation
- [x] `docker compose up -d --build` — all 6 containers start and report healthy
- [x] Python files compile cleanly